### PR TITLE
Update TMC26XStepper link 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,8 @@ lib_deps =
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
   https://github.com/ameyer/Arduino-L6470/archive/master.zip
-  https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
+  https://github.com/MarlinFirmware/TMC26XStepper/archive/0.1.1.zip
+
 
 #################################
 #                               #


### PR DESCRIPTION
Fix build failure due to change of location of TMC26XStepper lib.
(cf https://github.com/MarlinFirmware/Marlin/issues/24781)